### PR TITLE
Add `Send` and `Sync` bounds to `key_trans` in `Corpus`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,7 +431,7 @@ pub struct Corpus {
     pad_left: Pad,
     pad_right: Pad,
     ngrams: HashMap<String, Ngram>,
-    key_trans: Box<dyn Fn(&str) -> String + Send>,
+    key_trans: Box<dyn Fn(&str) -> String + Send + Sync>,
 }
 
 impl std::fmt::Debug for Corpus {
@@ -562,7 +562,7 @@ pub struct CorpusBuilder {
     pad_left: Pad,
     pad_right: Pad,
     texts: Vec<String>,
-    key_trans: Box<dyn Fn(&str) -> String + Send>,
+    key_trans: Box<dyn Fn(&str) -> String + Send + Sync>,
 }
 
 impl std::fmt::Debug for CorpusBuilder {
@@ -667,7 +667,7 @@ impl CorpusBuilder {
     /// }
     /// # }
     /// ```
-    pub fn key_trans(mut self, key_trans: Box<dyn Fn(&str) -> String + Send>) -> Self {
+    pub fn key_trans(mut self, key_trans: Box<dyn Fn(&str) -> String + Send + Sync>) -> Self {
         self.key_trans = key_trans;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,7 +431,7 @@ pub struct Corpus {
     pad_left: Pad,
     pad_right: Pad,
     ngrams: HashMap<String, Ngram>,
-    key_trans: Box<Fn(&str) -> String>,
+    key_trans: Box<dyn Fn(&str) -> String + Send>,
 }
 
 impl std::fmt::Debug for Corpus {
@@ -562,7 +562,7 @@ pub struct CorpusBuilder {
     pad_left: Pad,
     pad_right: Pad,
     texts: Vec<String>,
-    key_trans: Box<Fn(&str) -> String>,
+    key_trans: Box<dyn Fn(&str) -> String + Send>,
 }
 
 impl std::fmt::Debug for CorpusBuilder {
@@ -667,7 +667,7 @@ impl CorpusBuilder {
     /// }
     /// # }
     /// ```
-    pub fn key_trans(mut self, key_trans: Box<Fn(&str) -> String>) -> Self {
+    pub fn key_trans(mut self, key_trans: Box<dyn Fn(&str) -> String + Send>) -> Self {
         self.key_trans = key_trans;
         self
     }


### PR DESCRIPTION
Since `key_trans` is `Fn`, in the majority of use cases it'll be `Send + Sync`.

Adding these bounds marks `Corpus` as thread-safe, allowing shared concurrent access (there's no interior mutability in `Corpus` or any of its fields AFAIK) and sending the struct between threads.