### PR TITLE
Words smaller than arity  are not supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,7 +931,7 @@ mod tests {
         assert!(corpus.search("a", 0.).is_empty());
     }
 
-        #[test]
+    #[test]
     fn corpus_search_empty_string() {
         let corpus = CorpusBuilder::new()
             .arity(3)


### PR DESCRIPTION
Currently searching for a word smaller than arity cause: `thread 'main' panicked at 'attempt to subtract with overflow'`.
This fix modify `count_allgrams` to handle the case gracefully.
Let me know if any changes are needed or if this case should be handled differently 