### PR TITLE
Added `matches_with_warp` and `search_with_warp`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "ngrammatic"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Will Page <compenguy@gmail.com>"]
 description = "Character-oriented ngram generator and fuzzy matching library."
 homepage = "https://github.com/compenguy/ngrammatic"
 repository = "https://github.com/compenguy/ngrammatic"
+documentation = "https://docs.rs/ngrammatic"
 readme = "README.md"
 categories = ["text-processing"]
 keywords = ["fuzzy", "ngrams", "shingles"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Licensed under the MIT license.
 
 ### Documentation
 
-Not published yet.
-
+https://docs.rs/ngrammatic/latest/ngrammatic/
 
 ### Installation
 
@@ -19,7 +18,7 @@ To use it, add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-ngrammatic = "0.3.2"
+ngrammatic = "0.3.4"
 ```
 
 ### Usage


### PR DESCRIPTION
Addresses issue #3, allowing more control over how the closeness of a match is determined. This allows, for example, searching for the closest jaccard distance (warp = 1.0).
