### PR TITLE
Improve performance by limiting comparison to only relevant ngrams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,9 @@ assert_eq!(top_match.unwrap().text,String::from("tomato"));
 #![deny(missing_docs)]
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::f32;
+use std::hash::{Hash, Hasher};
 
 /// Holds a fuzzy match search result string, and its associated similarity
 /// to the query text.
@@ -146,6 +147,21 @@ pub struct Ngram {
     /// A collection of all generated ngrams for the text, with a
     /// count of how many times that ngram appears in the text
     pub grams: HashMap<String, usize>,
+}
+
+impl PartialEq for Ngram {
+    fn eq(&self, other: &Self) -> bool {
+        self.text_padded == other.text_padded &&
+            self.arity == other.arity
+    }
+}
+impl Eq for Ngram {}
+
+impl Hash for Ngram {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.text_padded.hash(state);
+        self.arity.hash(state);
+    }
 }
 
 // TODO: When rust adds const generics
@@ -455,6 +471,7 @@ pub struct Corpus {
     pad_left: Pad,
     pad_right: Pad,
     ngrams: HashMap<String, Ngram>,
+    gram_to_ngram: HashMap<String, Vec<Ngram>>,
     key_trans: Box<dyn Fn(&str) -> String + Send + Sync>,
 }
 
@@ -490,7 +507,11 @@ impl Corpus {
     /// ```
     #[allow(dead_code)]
     pub fn add_ngram(&mut self, ngram: Ngram) {
-        self.ngrams.insert(ngram.text.to_string(), ngram);
+        self.ngrams.insert(ngram.text.to_string(), ngram.clone());
+        for gram in ngram.grams.keys() {
+            let ngram_list = self.gram_to_ngram.entry(gram.clone()).or_insert_with(Vec::new);
+            ngram_list.push(ngram.clone());
+        }
     }
 
     /// Generate an `Ngram` for the supplied `text`, and add it to the
@@ -585,9 +606,15 @@ impl Corpus {
             .pad_left(self.pad_left.clone())
             .pad_right(self.pad_right.clone())
             .finish();
-        let mut results: Vec<SearchResult> = self
-            .ngrams
-            .values()
+        let mut ngrams_to_consider: HashSet<&Ngram> = HashSet::new();
+        for gram in item.grams.keys() {
+            if let Some(ngrams) =  self.gram_to_ngram.get(gram) {
+                ngrams_to_consider.extend(ngrams.iter());
+            }
+        }
+
+        let mut results: Vec<SearchResult> = ngrams_to_consider
+            .iter()
             .filter_map(|n| item.matches_with_warp(n, warp, threshold))
             .collect();
 
@@ -740,6 +767,7 @@ impl CorpusBuilder {
         let mut corpus = Corpus {
             arity: self.arity,
             ngrams: HashMap::new(),
+            gram_to_ngram: HashMap::new(),
             pad_left: self.pad_left,
             pad_right: self.pad_right,
             key_trans: self.key_trans,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,12 +606,10 @@ impl Corpus {
             .pad_left(self.pad_left.clone())
             .pad_right(self.pad_right.clone())
             .finish();
-        let mut ngrams_to_consider: HashSet<&Ngram> = HashSet::new();
-        for gram in item.grams.keys() {
-            if let Some(ngrams) =  self.gram_to_ngram.get(gram) {
-                ngrams_to_consider.extend(ngrams.iter());
-            }
-        }
+        let ngrams_to_consider: HashSet<&Ngram> = item.grams.keys()
+                                             .filter_map(|g| self.gram_to_ngram.get(g))
+                                             .flatten()
+                                             .collect();
 
         let mut results: Vec<SearchResult> = ngrams_to_consider
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,8 +607,11 @@ impl Corpus {
             .pad_right(self.pad_right.clone())
             .finish();
         let mut ngrams_to_consider: HashSet<&Ngram> = HashSet::new();
-        for matching_word in item.grams.keys().filter_map(|g| self.gram_to_words.get(g)) {
-            ngrams_to_consider.extend(matching_word.iter().filter_map(|word| self.ngrams.get(word)));
+        for gram in item.grams.keys() {
+            if let Some(words) =  self.gram_to_words.get(gram) {
+                // Fetch ngrams from raw words
+                ngrams_to_consider.extend(words.iter().filter_map(|word| self.ngrams.get(word)));
+            }
         }
         let mut results: Vec<SearchResult> = ngrams_to_consider
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,11 +607,8 @@ impl Corpus {
             .pad_right(self.pad_right.clone())
             .finish();
         let mut ngrams_to_consider: HashSet<&Ngram> = HashSet::new();
-        for gram in item.grams.keys() {
-            if let Some(words) =  self.gram_to_words.get(gram) {
-                // Fetch ngrams from raw words
-                ngrams_to_consider.extend(words.iter().filter_map(|word| self.ngrams.get(word)));
-            }
+        for matching_word in item.grams.keys().filter_map(|g| self.gram_to_words.get(g)) {
+            ngrams_to_consider.extend(matching_word.iter().filter_map(|word| self.ngrams.get(word)));
         }
         let mut results: Vec<SearchResult> = ngrams_to_consider
             .iter()


### PR DESCRIPTION
Hey, 
I have been trying to improve the search performance by not testing the whole corpus, but only testing the similarity against texts in the corpus which have at least a common ngram with the input text.
A downside is that it requires to compute and store an extra hashmap.

I have put a benchmark file in a separated branch so as to not "pollute" this PR: https://github.com/Hugo-C/ngrammatic/tree/performance_improvement_benchmark
For a single search in a corpus of 7 words, the improvement is not outstanding at ~18%:
![image](https://user-images.githubusercontent.com/24675917/152069553-aeec0f32-5709-4288-90db-0281b0a379f5.png)

For 20 searches in a corpus of 100 randoms words, the improvement is more significant at ~94%:
![image](https://user-images.githubusercontent.com/24675917/152069764-23606fe4-17e8-43f8-8ef6-fbc764e127b3.png)
The full benchmark report: [criterion.zip](https://github.com/compenguy/ngrammatic/files/7982608/criterion.zip)

Please let me know your opinion